### PR TITLE
Adding Tracy Debugger

### DIFF
--- a/_docs/debugging.md
+++ b/_docs/debugging.md
@@ -1,0 +1,23 @@
+# Debugging
+
+Monarch integrates [Tracy](https://tracy.nette.org/en/) to provide a powerful debugging experience. This includes a debug bar, error logging, an error screen, a stopwatch, IDE integration, and more. And it's fully expandable with [plugins](https://componette.org/search/tracy).
+
+## Enabling Error Logging
+
+Tracy is always enabled, as it handles error logging and error screens.
+
+## Enabling the Debug Bar
+
+While Tracy is always enabled, the debug bar is only enabled when the `DEBUG` environment variable is set to `1`. This is done in the `.env` file.
+
+```env
+DEBUG=1
+```
+
+## Configuration
+
+Tracy can be configured in the `config/tracy.php` file. This file is automatically loaded by Tracy. See Tracy's [configuration documentation](https://tracy.nette.org/en/configuring) for more information.
+
+## Known Issues
+
+Tracy will not show up when clicking on HTMX-boosted links. I will continue to look into this. In the meantime, you can manually refresh the page to see the debug bar, or design your application to not rely on boosted links for debugging purposes.

--- a/_docs/helpers/str.md
+++ b/_docs/helpers/str.md
@@ -100,6 +100,25 @@ Str::containsAll('foo_bar', ['foo', 'bar']);
 // true
 ```
 
+### `like(string $pattern, string $value): bool`
+
+Check if the given string matches the given pattern. The pattern can contain the following wildcards:
+
+- `%` matches zero or more characters
+- `*` matches zero or more characters
+- '?' matches a single character
+
+It returns a boolean value indicating whether the string matches the pattern.
+
+```php
+use Monarch\Helpers\Str;
+
+Str::like('foo*', 'foobar');
+
+// true
+```
+
+
 ### `length(string $value): int`
 
 Get the length of the given string.

--- a/app/components/navbar.php
+++ b/app/components/navbar.php
@@ -1,4 +1,4 @@
-<nav hx-boost="true">
+<nav>
     <div class="nav justify-content-center bg-dark py-3">
         <x-slot></x-slot>
     </div>

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,8 @@
     "require": {
         "php": ">=8.2",
         "league/commonmark": "^2.4",
-        "symfony/yaml": "^7.0"
+        "symfony/yaml": "^7.0",
+        "tracy/tracy": "^2.10"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.49",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ece70d8b713f0ebf2b0dc784a45a762f",
+    "content-hash": "b795eb151a2d4c9fd00f43df11133624",
     "packages": [
         {
             "name": "dflydev/dot-access-data",
@@ -763,6 +763,81 @@
                 }
             ],
             "time": "2024-05-31T14:57:53+00:00"
+        },
+        {
+            "name": "tracy/tracy",
+            "version": "v2.10.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nette/tracy.git",
+                "reference": "7e7b25ba103968d5318d37db330b2e9c755dc765"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nette/tracy/zipball/7e7b25ba103968d5318d37db330b2e9c755dc765",
+                "reference": "7e7b25ba103968d5318d37db330b2e9c755dc765",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "ext-session": "*",
+                "php": ">=8.0 <8.4"
+            },
+            "conflict": {
+                "nette/di": "<3.0"
+            },
+            "require-dev": {
+                "latte/latte": "^2.5",
+                "nette/di": "^3.0",
+                "nette/http": "^3.0",
+                "nette/mail": "^3.0",
+                "nette/tester": "^2.2",
+                "nette/utils": "^3.0",
+                "phpstan/phpstan": "^1.0",
+                "psr/log": "^1.0 || ^2.0 || ^3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.10-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/Tracy/functions.php"
+                ],
+                "classmap": [
+                    "src"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "David Grudl",
+                    "homepage": "https://davidgrudl.com"
+                },
+                {
+                    "name": "Nette Community",
+                    "homepage": "https://nette.org/contributors"
+                }
+            ],
+            "description": "😎  Tracy: the addictive tool to ease debugging PHP code for cool developers. Friendly design, logging, profiler, advanced features like debugging AJAX calls or CLI support. You will love it.",
+            "homepage": "https://tracy.nette.org",
+            "keywords": [
+                "Xdebug",
+                "debug",
+                "debugger",
+                "nette",
+                "profiler"
+            ],
+            "support": {
+                "issues": "https://github.com/nette/tracy/issues",
+                "source": "https://github.com/nette/tracy/tree/v2.10.7"
+            },
+            "time": "2024-04-29T11:44:00+00:00"
         }
     ],
     "packages-dev": [
@@ -1737,16 +1812,16 @@
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.11.1",
+            "version": "1.12.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "7284c22080590fb39f2ffa3e9057f10a4ddd0e0c"
+                "reference": "3a6b9a42cd8f8771bd4295d13e1423fa7f3d942c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/7284c22080590fb39f2ffa3e9057f10a4ddd0e0c",
-                "reference": "7284c22080590fb39f2ffa3e9057f10a4ddd0e0c",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/3a6b9a42cd8f8771bd4295d13e1423fa7f3d942c",
+                "reference": "3a6b9a42cd8f8771bd4295d13e1423fa7f3d942c",
                 "shasum": ""
             },
             "require": {
@@ -1754,11 +1829,12 @@
             },
             "conflict": {
                 "doctrine/collections": "<1.6.8",
-                "doctrine/common": "<2.13.3 || >=3,<3.2.2"
+                "doctrine/common": "<2.13.3 || >=3 <3.2.2"
             },
             "require-dev": {
                 "doctrine/collections": "^1.6.8",
                 "doctrine/common": "^2.13.3 || ^3.2.2",
+                "phpspec/prophecy": "^1.10",
                 "phpunit/phpunit": "^7.5.20 || ^8.5.23 || ^9.5.13"
             },
             "type": "library",
@@ -1784,7 +1860,7 @@
             ],
             "support": {
                 "issues": "https://github.com/myclabs/DeepCopy/issues",
-                "source": "https://github.com/myclabs/DeepCopy/tree/1.11.1"
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.12.0"
             },
             "funding": [
                 {
@@ -1792,7 +1868,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-03-08T13:26:56+00:00"
+            "time": "2024-06-12T14:39:25+00:00"
         },
         {
             "name": "nikic/php-parser",
@@ -3594,28 +3670,28 @@
         },
         {
             "name": "react/dns",
-            "version": "v1.12.0",
+            "version": "v1.13.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/reactphp/dns.git",
-                "reference": "c134600642fa615b46b41237ef243daa65bb64ec"
+                "reference": "eb8ae001b5a455665c89c1df97f6fb682f8fb0f5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/reactphp/dns/zipball/c134600642fa615b46b41237ef243daa65bb64ec",
-                "reference": "c134600642fa615b46b41237ef243daa65bb64ec",
+                "url": "https://api.github.com/repos/reactphp/dns/zipball/eb8ae001b5a455665c89c1df97f6fb682f8fb0f5",
+                "reference": "eb8ae001b5a455665c89c1df97f6fb682f8fb0f5",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.0",
                 "react/cache": "^1.0 || ^0.6 || ^0.5",
                 "react/event-loop": "^1.2",
-                "react/promise": "^3.0 || ^2.7 || ^1.2.1"
+                "react/promise": "^3.2 || ^2.7 || ^1.2.1"
             },
             "require-dev": {
                 "phpunit/phpunit": "^9.6 || ^5.7 || ^4.8.36",
-                "react/async": "^4 || ^3 || ^2",
-                "react/promise-timer": "^1.9"
+                "react/async": "^4.3 || ^3 || ^2",
+                "react/promise-timer": "^1.11"
             },
             "type": "library",
             "autoload": {
@@ -3658,7 +3734,7 @@
             ],
             "support": {
                 "issues": "https://github.com/reactphp/dns/issues",
-                "source": "https://github.com/reactphp/dns/tree/v1.12.0"
+                "source": "https://github.com/reactphp/dns/tree/v1.13.0"
             },
             "funding": [
                 {
@@ -3666,7 +3742,7 @@
                     "type": "open_collective"
                 }
             ],
-            "time": "2023-11-29T12:41:06+00:00"
+            "time": "2024-06-13T14:18:03+00:00"
         },
         {
             "name": "react/event-loop",
@@ -3895,16 +3971,16 @@
         },
         {
             "name": "react/stream",
-            "version": "v1.3.0",
+            "version": "v1.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/reactphp/stream.git",
-                "reference": "6fbc9672905c7d5a885f2da2fc696f65840f4a66"
+                "reference": "1e5b0acb8fe55143b5b426817155190eb6f5b18d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/reactphp/stream/zipball/6fbc9672905c7d5a885f2da2fc696f65840f4a66",
-                "reference": "6fbc9672905c7d5a885f2da2fc696f65840f4a66",
+                "url": "https://api.github.com/repos/reactphp/stream/zipball/1e5b0acb8fe55143b5b426817155190eb6f5b18d",
+                "reference": "1e5b0acb8fe55143b5b426817155190eb6f5b18d",
                 "shasum": ""
             },
             "require": {
@@ -3914,7 +3990,7 @@
             },
             "require-dev": {
                 "clue/stream-filter": "~1.2",
-                "phpunit/phpunit": "^9.5 || ^5.7 || ^4.8.35"
+                "phpunit/phpunit": "^9.6 || ^5.7 || ^4.8.36"
             },
             "type": "library",
             "autoload": {
@@ -3961,7 +4037,7 @@
             ],
             "support": {
                 "issues": "https://github.com/reactphp/stream/issues",
-                "source": "https://github.com/reactphp/stream/tree/v1.3.0"
+                "source": "https://github.com/reactphp/stream/tree/v1.4.0"
             },
             "funding": [
                 {
@@ -3969,7 +4045,7 @@
                     "type": "open_collective"
                 }
             ],
-            "time": "2023-06-16T10:52:11+00:00"
+            "time": "2024-06-11T12:45:25+00:00"
         },
         {
             "name": "rector/rector",
@@ -4036,12 +4112,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Roave/SecurityAdvisories.git",
-                "reference": "cac81dc38cb1ea099552433245d0790b6e172211"
+                "reference": "2e530fa2b00d046ceb5660f3139af583170ea7f9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/cac81dc38cb1ea099552433245d0790b6e172211",
-                "reference": "cac81dc38cb1ea099552433245d0790b6e172211",
+                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/2e530fa2b00d046ceb5660f3139af583170ea7f9",
+                "reference": "2e530fa2b00d046ceb5660f3139af583170ea7f9",
                 "shasum": ""
             },
             "conflict": {
@@ -4361,7 +4437,7 @@
                 "lms/routes": "<2.1.1",
                 "localizationteam/l10nmgr": "<7.4|>=8,<8.7|>=9,<9.2",
                 "luyadev/yii-helpers": "<1.2.1",
-                "magento/community-edition": "<2.4.3.0-patch3|>=2.4.4,<2.4.5",
+                "magento/community-edition": "<2.4.5|==2.4.5|>=2.4.5.0-patch1,<2.4.5.0-patch8|==2.4.6|>=2.4.6.0-patch1,<2.4.6.0-patch6|==2.4.7",
                 "magento/core": "<=1.9.4.5",
                 "magento/magento1ce": "<1.9.4.3-dev",
                 "magento/magento1ee": ">=1,<1.14.4.3-dev",
@@ -4729,7 +4805,7 @@
                 "winter/wn-dusk-plugin": "<2.1",
                 "winter/wn-system-module": "<1.2.4",
                 "wintercms/winter": "<=1.2.3",
-                "woocommerce/woocommerce": "<6.6",
+                "woocommerce/woocommerce": "<6.6|>=8.8,<8.8.5|>=8.9,<8.9.3",
                 "wp-cli/wp-cli": ">=0.12,<2.5",
                 "wp-graphql/wp-graphql": "<=1.14.5",
                 "wp-premium/gravityforms": "<2.4.21",
@@ -4831,7 +4907,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-06-10T22:04:51+00:00"
+            "time": "2024-06-13T20:04:44+00:00"
         },
         {
             "name": "sebastian/cli-parser",

--- a/config/middleware.php
+++ b/config/middleware.php
@@ -8,7 +8,7 @@ return [
     // The middleware classes to run through
     // for standard 'web' requests.
     'web' => [
-        //
+        \Monarch\HTTP\Middleware\Debugger::class,
     ],
 
     // The middleware classes to run through

--- a/config/tracy.php
+++ b/config/tracy.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * Tracy Configuration
+ *
+ * This file contains the configuration options for Tracy.
+ * See the Tracy documentation for more information.
+ *
+ * @see  https://tracy.nette.org/en/configuring
+ */
+return [
+    /*
+     * Error Logging
+     */
+    // 'email' => null,
+    // 'fromEmail' => null,
+    // 'mailer' => null,
+    // 'emailSnooze' => 0,
+    'logSeverity' => E_ALL & ~E_NOTICE & ~E_STRICT & ~E_DEPRECATED,
+    'logDirectory' => WRITEPATH . 'logs',
+
+    /*
+     * Dump Behavior
+     */
+    'maxLength' => 150,
+    'maxDepth' => 10,
+    'keysToHide' => ['password'],
+    'dumpTheme' => 'dark',
+    'showLocation' => true,
+
+    /*
+     * Other Settings
+     */
+    'strictMode' => true,
+    'scream' => false,
+    'editor' => 'vscode://file/%file:%line',
+    'errorTemplate' => null,
+    'showBar' => true,
+];

--- a/monarch/App.php
+++ b/monarch/App.php
@@ -41,39 +41,35 @@ class App
      */
     public function run()
     {
-        try {
-            $this->prepareEnvironment();
+        $this->prepareEnvironment();
 
-            ob_start();
+        ob_start();
 
-            // Get the control file, if exists
-            $router = new Router();
-            $router->setBasePath(ROOTPATH .'routes');
-            $route = $router->getRouteForRequest($this->request);
+        // Get the control file, if exists
+        $router = new Router();
+        $router->setBasePath(ROOTPATH .'routes');
+        $route = $router->getRouteForRequest($this->request);
 
-            /** @var object */
-            $control = $route->controlFile !== '' ? include $route->controlFile : null;
+        /** @var object */
+        $control = $route->controlFile !== '' ? include $route->controlFile : null;
 
-            $action = fn (Request $request, Response $response) => $router->display(
-                request: $request,
-                control: $control,
-                route: $route
-            );
+        $action = fn (Request $request, Response $response) => $router->display(
+            request: $request,
+            control: $control,
+            route: $route
+        );
 
-            // Run the middleware
-            $request = $this->request;
-            $response = Response::createFromRequest($request);
-            $html =  Middleware::forRequest($request)
+        // Run the middleware
+        $request = $this->request;
+        $response = Response::createFromRequest($request);
+        $html =  Middleware::forRequest($request)
                 ->forControl($control)
                 ->process($request, $response, $action);
 
-            $response->withBody($html);
-            $response->withBody($this->replacePerformanceMarkers($response->body()));
+        $response->withBody($html);
+        $response->withBody($this->replacePerformanceMarkers($response->body()));
 
-            return $response->send();
-        } catch (Throwable $e) {
-            return $this->handleException($e);
-        }
+        return $response->send();
     }
 
     public function processMiddleware(Request $request, Response $response, array $middleware)
@@ -137,28 +133,5 @@ class App
         $output = str_replace('{memory_usage}', "{$currentMemory}/{$peakMemory}", $output);
 
         return $output;
-    }
-
-    private function handleException(Throwable $e)
-    {
-        if (ENVIRONMENT === 'testing') {
-            throw $e;
-        }
-
-        $type = $e::class;
-        $message = $e->getMessage();
-        $code = $e->getCode();
-        $file = $e->getFile();
-        $line = $e->getLine();
-        $trace = $e->getTraceAsString();
-
-        // TODO - Log the error
-        // TODO - Used per-environment error pages
-        // TODO - Hande HTTP status codes
-        ob_start();
-        include ROOTPATH .'routes/+error.php';
-        echo ob_get_clean() ?? '';
-
-        exit(1);
     }
 }

--- a/monarch/Config.php
+++ b/monarch/Config.php
@@ -59,6 +59,10 @@ class Config
             $this->files[$file] = include $path;
         }
 
+        if (count($keys) === 0) {
+            return $this->files[$file] ?? null;
+        }
+
         return dot_array_search(implode('.', $keys), $this->files[$file]);
     }
 }

--- a/monarch/Debug.php
+++ b/monarch/Debug.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Monarch;
+
+use Tracy\Debugger;
+
+class Debug
+{
+    /**
+     * Starts Tracy debugger and set its configuration.
+     */
+    public static function startTracy(): void
+    {
+        $config = config('tracy');
+        $tracy = Debugger::getBar();
+
+        foreach ($config as $key => $value) {
+            if ($value === null) {
+                continue;
+            }
+
+            Debugger::${$key} = $value;
+        }
+
+        Debugger::enable(env('DEBUG') ? Debugger::Development : Debugger::Production);
+    }
+}

--- a/monarch/HTTP/Middleware.php
+++ b/monarch/HTTP/Middleware.php
@@ -6,9 +6,10 @@ class Middleware
 {
     private static self $instance;
 
-    private function __construct(private Request $request)
-    {
-        //
+    private function __construct(
+        private Request $request,
+        private array $middleware = []
+    ) {
     }
 
     /**
@@ -31,7 +32,7 @@ class Middleware
      * If the control returns a string with a middleware group name,
      * it will return the middleware for that group.
      */
-    public function forControl(?object $control = null): array
+    public function forControl(?object $control = null): self
     {
         $middleware = is_object($control) && method_exists($control, 'middleware')
             ? $control?->middleware($this->request->method)
@@ -45,8 +46,51 @@ class Middleware
             $middleware = config("middleware.{$middleware}");
         }
 
-        return is_array($middleware)
+        $this->middleware = is_array($middleware)
             ? $middleware
             : [];
+
+        return $this;
+    }
+
+    /**
+     * Set the middleware classes to be processed.
+     */
+    public function setMiddleware(array $middleware): self
+    {
+        $this->middleware = $middleware;
+
+        return $this;
+    }
+
+    /**
+     * Get the middleware classes to be processed.
+     */
+    public function middleware(): array
+    {
+        return $this->middleware;
+    }
+
+    /**
+     * Process all middleware classes, breaking if a response is returned.
+     */
+    public function process(Request $request, Response $response, callable $next)
+    {
+        $chain = array_reduce(
+            // Middleware classes
+            array_reverse($this->middleware),
+            // Callback
+            function ($next, $middleware) {
+                if (is_string($middleware)) {
+                    $middleware = new $middleware();
+                }
+
+                return fn ($request, $response) => $middleware->handle($request, $response, $next);
+            },
+            // Initial value
+            $next
+        );
+
+        return $chain($request, $response);
     }
 }

--- a/monarch/HTTP/Middleware/Debugger.php
+++ b/monarch/HTTP/Middleware/Debugger.php
@@ -12,12 +12,14 @@ class Debugger
 {
     public function handle(Request $request, Response $response, Closure $next)
     {
-        // Attach Tracy to the end of the content if it's enabled
+        // Ensure Tracy can track AJAX requests
         if (DEBUG && $request->isHtmx()) {
             TracyDebugger::dispatch();
             $response->withHeader(new Header('X-Tracy-Ajax', '1'));
         }
 
-        return $next($request, $response);
+        $html = $next($request, $response);
+
+        return $html;
     }
 }

--- a/monarch/HTTP/Middleware/Debugger.php
+++ b/monarch/HTTP/Middleware/Debugger.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Monarch\HTTP\Middleware;
+
+use Closure;
+use Monarch\HTTP\Header;
+use Monarch\HTTP\Request;
+use Monarch\HTTP\Response;
+use Tracy\Debugger as TracyDebugger;
+
+class Debugger
+{
+    public function handle(Request $request, Response $response, Closure $next)
+    {
+        // Attach Tracy to the end of the content if it's enabled
+        if (DEBUG && $request->isHtmx()) {
+            TracyDebugger::dispatch();
+            $response->withHeader(new Header('X-Tracy-Ajax', '1'));
+        }
+
+        return $next($request, $response);
+    }
+}

--- a/monarch/View/Renderers/HTMLRenderer.php
+++ b/monarch/View/Renderers/HTMLRenderer.php
@@ -4,13 +4,11 @@ declare(strict_types=1);
 
 namespace Monarch\View\Renderers;
 
-use Monarch\Components\ComponentManager;
 use Monarch\Components\HasComponents;
-use Monarch\Components\TagParser;
 use Monarch\HTTP\Request;
 use Monarch\View\HasLayouts;
 use Monarch\View\RendererInterface;
-use RuntimeException;
+use Tracy\Debugger;
 
 class HTMLRenderer implements RendererInterface
 {

--- a/monarch/helpers/Str.php
+++ b/monarch/helpers/Str.php
@@ -11,6 +11,9 @@ class Str
      */
     public static function pascal(string $string): string
     {
+        // Insert hyphen before capital letters inside string
+        $string = preg_replace('/([a-z])([A-Z])/', '$1-$2', $string);
+
         return str_replace(' ', '', ucwords(str_replace(['-', '_'], ' ', mb_strtolower($string))));
     }
 
@@ -19,6 +22,9 @@ class Str
      */
     public static function camel(string $string): string
     {
+        // Insert hyphen before capital letters inside string
+        $string = preg_replace('/([a-z])([A-Z])/', '$1-$2', $string);
+
         return str_replace(' ', '', lcfirst(ucwords(str_replace(['-', '_'], ' ', mb_strtolower($string)))));
     }
 
@@ -27,6 +33,9 @@ class Str
      */
     public static function kebab(string $string): string
     {
+        // Insert hyphen before capital letters inside string
+        $string = preg_replace('/([a-z])([A-Z])/', '$1-$2', $string);
+
         return str_replace([' ', '_'], '-', mb_strtolower($string));
     }
 
@@ -35,6 +44,9 @@ class Str
      */
     public static function snake(string $string): string
     {
+        // Insert hyphen before capital letters inside string
+        $string = preg_replace('/([a-z])([A-Z])/', '$1-$2', $string);
+
         return str_replace(' ', '_', str_replace([' ', '-'], ' ', mb_strtolower($string)));
     }
 
@@ -43,6 +55,9 @@ class Str
      */
     public static function title(string $string): string
     {
+        // Insert hyphen before capital letters inside string
+        $string = preg_replace('/([a-z])([A-Z])/', '$1-$2', $string);
+
         return ucwords(str_replace(['-', '_'], ' ', mb_strtolower($string)));
     }
 
@@ -117,7 +132,20 @@ class Str
     public static function like(string $str, string $pattern): bool
     {
         $pattern = mb_strtolower($pattern);
-        $pattern = str_replace('%', '.*', preg_quote($pattern, '/'));
+
+        // Asterisks are translated into zero-or-more regular expression wildcards
+        if (mb_strpos($pattern, '*') !== false) {
+            $pattern = str_replace('*', '.*', $pattern);
+        }
+
+        // Question marks are translated into zero-or-one regular expression wildcards
+        if (mb_strpos($pattern, '?') !== false) {
+            $pattern = str_replace('?', '.', $pattern);
+        }
+        // Percent signs are translated into zero-or-more regular expression wildcards
+        if (mb_strpos($pattern, '%') !== false) {
+            $pattern = str_replace('%', '.*', preg_quote($pattern, '/'));
+        }
 
         return (bool) preg_match('/^' . $pattern . '\z/', $str);
     }
@@ -141,7 +169,9 @@ class Str
      */
     public static function random(int $length = 16): string
     {
-        return bin2hex(random_bytes($length));
+        $str = bin2hex(random_bytes(ceil($length / 2)));
+
+        return substr($str, 0, $length);
     }
 
     /**

--- a/monarch/helpers/common.php
+++ b/monarch/helpers/common.php
@@ -1,25 +1,8 @@
 <?php
 
-use Kint\Kint;
-use Kint\Renderer\RichRenderer;
 use Monarch\View\Meta;
 use Monarch\Config;
 use Monarch\Database\Connection;
-
-/**
- * Setup Kint
- */
-Kint::$aliases[] = 'dd';
-Kint::$expanded = true;
-RichRenderer::$theme = 'aante-light.css';
-
-if (! function_exists('dd')) {
-    function dd(...$vars): never
-    {
-        Kint::dump(...$vars);
-        exit;
-    }
-}
 
 /**
  * Retrieves a key from config files.

--- a/monarch/helpers/common.php
+++ b/monarch/helpers/common.php
@@ -126,7 +126,7 @@ if (! function_exists('dot_array_search')) {
  * @return array|false|string|null
  */
 if (! function_exists('env')) {
-    function env(string $key, ?string $default)
+    function env(string $key, ?string $default = null)
     {
         $value = getenv($key);
 

--- a/public/index.php
+++ b/public/index.php
@@ -1,6 +1,7 @@
 <?php
 
 use Monarch\App;
+use Tracy\Debugger;
 
 // Hook up Composer
 include_once '../vendor/autoload.php';
@@ -14,4 +15,16 @@ define('TESTPATH', realpath(ROOTPATH.'tests') .'/');
 define('MONARCHPATH', realpath(ROOTPATH.'monarch') .'/');
 define('WRITEPATH', realpath(ROOTPATH.'writable') .'/');
 
-echo App::createFromGlobals()->run();
+$app = App::createFromGlobals();
+$app->prepareEnvironment();
+
+if (! defined('DEBUG')) {
+    define('DEBUG', (bool)getenv('DEBUG'));
+}
+
+// Setup Tracy Debugger
+if (getenv('DEBUG')) {
+    Debugger::enable(Debugger::Development);
+}
+
+echo $app->run();

--- a/public/index.php
+++ b/public/index.php
@@ -1,6 +1,7 @@
 <?php
 
 use Monarch\App;
+use Monarch\Debug;
 use Tracy\Debugger;
 
 // Hook up Composer
@@ -22,9 +23,6 @@ if (! defined('DEBUG')) {
     define('DEBUG', (bool)getenv('DEBUG'));
 }
 
-// Setup Tracy Debugger
-if (getenv('DEBUG')) {
-    Debugger::enable(Debugger::Development);
-}
+Debug::startTracy();
 
 echo $app->run();

--- a/routes/+layout.php
+++ b/routes/+layout.php
@@ -15,7 +15,7 @@
     <?= viewMeta()->output('rawScripts') ?>
 </head>
 
-<body>
+<body hx-headers="{'X-Tracy-Ajax': Tracy.getAjaxHeader() }">
     <div class="main">
         <x-navbar>
             <ul class="nav">

--- a/routes/+layout.php
+++ b/routes/+layout.php
@@ -10,7 +10,7 @@
 
     <link href="/css/vendor/bootstrap-5.3.min.css" rel="stylesheet">
     <?= viewMeta()->output('styles') ?>
-    <script src="/js/vendor/htmx-1.9.11.min.js"></script>
+    <script src="/js/vendor/htmx-2.0.0.min.js"></script>
     <?= viewMeta()->output('scripts') ?>
     <?= viewMeta()->output('rawScripts') ?>
 </head>

--- a/tests/Database/ConnectionTest.php
+++ b/tests/Database/ConnectionTest.php
@@ -91,30 +91,22 @@ describe('Database Connection', function () {
     });
 
     test('run query', function () {
-        $config = config('database.'. config('database.default'));
-        $connection = Connection::createWithConfig($config);
+        db()->dropTable('users');
+        db()->run('CREATE TABLE users (id INT PRIMARY KEY AUTO_INCREMENT, name TEXT)');
+        db()->run('INSERT INTO users (name) VALUES (?)', ['foo']);
+        db()->run('INSERT INTO users (name) VALUES (?)', ['bar']);
 
-        $connection->run('CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT)');
-        $connection->run('INSERT INTO users (name) VALUES (?)', ['foo']);
-        $connection->run('INSERT INTO users (name) VALUES (?)', ['bar']);
-
-        $users = $connection->run('SELECT * FROM users')->fetchAll();
+        $users = db()->run('SELECT * FROM users')->fetchAll();
         expect($users)->toHaveCount(2);
-
-        $connection->dropTable('users');
     });
 
     test('run query with QueryBuilder', function () {
-        $config = config('database.'. config('database.default'));
-        $connection = Connection::createWithConfig($config);
+        db()->dropTable('users');
+        db()->run('CREATE TABLE users (id INT PRIMARY KEY AUTO_INCREMENT, name TEXT)');
+        db()->run('INSERT INTO users (name) VALUES (?)', ['foo']);
+        db()->run('INSERT INTO users (name) VALUES (?)', ['bar']);
 
-        $connection->run('CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT)');
-        $connection->run('INSERT INTO users (name) VALUES (?)', ['foo']);
-        $connection->run('INSERT INTO users (name) VALUES (?)', ['bar']);
-
-        $users = $connection->sql('SELECT * FROM users')->run()->fetchAll();
+        $users = db()->sql('SELECT * FROM users')->run()->fetchAll();
         expect($users)->toHaveCount(2);
-
-        $connection->dropTable('users');
     });
 });

--- a/tests/Database/MigrationTest.php
+++ b/tests/Database/MigrationTest.php
@@ -11,7 +11,6 @@ describe('Migrations', function () {
         db()->dropTable('migrations');
         db()->dropTable('users');
         db()->dropTable('posts');
-        ;
     });
 
     it('should run all pending migrations recursively', function () {

--- a/tests/Database/TableTest.php
+++ b/tests/Database/TableTest.php
@@ -4,6 +4,7 @@ use Monarch\Database\Connection;
 use Monarch\Helpers\Str;
 
 beforeEach(function () {
+    db()->dropTable('migrations');
     db()->dropTable('users');
     db()->dropTable('posts');
 });
@@ -17,7 +18,10 @@ describe('Database Tables', function () {
     });
 
     test('can list tables with no tables', function () {
-        expect(db()->tables())->toBeArray()->toBeEmpty();
+        $tables = db()->tables();
+
+        expect($tables)->toBeArray();
+        expect($tables)->toBeEmpty();
     });
 
     test('can list tables', function () {

--- a/tests/Helpers/StrTest.php
+++ b/tests/Helpers/StrTest.php
@@ -4,7 +4,7 @@ use Monarch\Helpers\Str;
 
 describe('Str', function () {
     test('pascal from snake_case', function () {
-        $input = 'hello_wOrLd';
+        $input = 'hello_world';
         $expectedOutput = 'HelloWorld';
 
         $output = Str::pascal($input);
@@ -13,7 +13,7 @@ describe('Str', function () {
     });
 
     test('pascal from kebab-case', function () {
-        $input = 'hello-wOrLd';
+        $input = 'hello-world';
         $expectedOutput = 'HelloWorld';
 
         $output = Str::pascal($input);
@@ -31,7 +31,7 @@ describe('Str', function () {
     });
 
     test('camel from snake_case', function () {
-        $input = 'hello_wOrLd';
+        $input = 'hello_world';
         $expectedOutput = 'helloWorld';
 
         $output = Str::camel($input);
@@ -40,7 +40,7 @@ describe('Str', function () {
     });
 
     test('camel from kebab-case', function () {
-        $input = 'hello-wOrLd';
+        $input = 'hello-world';
         $expectedOutput = 'helloWorld';
 
         $output = Str::camel($input);
@@ -58,7 +58,7 @@ describe('Str', function () {
     });
 
     test('kebab from snake_case', function () {
-        $input = 'hello_wOrLd';
+        $input = 'hello_world';
         $expectedOutput = 'hello-world';
 
         $output = Str::kebab($input);
@@ -112,7 +112,7 @@ describe('Str', function () {
     });
 
     test('title from snake_case', function () {
-        $input = 'hello_wOrLd';
+        $input = 'hello_world';
         $expectedOutput = 'Hello World';
 
         $output = Str::title($input);
@@ -316,6 +316,12 @@ describe('Str', function () {
         expect($output)->toMatch('/^[a-zA-Z0-9]{16}$/');
     });
 
+    test('random with odd number', function () {
+        $output = Str::random(15);
+
+        expect($output)->toMatch('/^[a-zA-Z0-9]{15}$/');
+    });
+
     test('words', function () {
         $input = 'hello world';
 
@@ -338,5 +344,29 @@ describe('Str', function () {
         $output = Str::words($input, 5);
 
         expect($output)->toEqual('hello world');
+    });
+
+    test('like with database delimiter', function () {
+        $input = 'hello world';
+
+        $output = Str::like($input, '%ello%');
+
+        expect($output)->toBeTrue();
+    });
+
+    test('like with asterisk', function () {
+        $input = 'hello world';
+
+        $output = Str::like($input, 'hello*');
+
+        expect($output)->toBeTrue();
+    });
+
+    test('like with question mark', function () {
+        $input = 'hello world';
+
+        $output = Str::like($input, '?ello*');
+
+        expect($output)->toBeTrue();
     });
 });

--- a/tests/_support/Middleware/BodyPrinter.php
+++ b/tests/_support/Middleware/BodyPrinter.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Tests\_support\Middleware;
+
+class BodyPrinter
+{
+    public function handle($request, $response, $next)
+    {
+        $response->withBody('Hello, world!');
+
+        return $next($request, $response);
+    }
+}


### PR DESCRIPTION
- Refactored Middleware to work correctly. 
- Pull in the [Tracy Debugger](https://tracy.nette.org/en/) package. 
- Created a new middleware to dispatch Tracy when an HTMX request is happening and we need a layout (so a boosted method). 
- In the root `+layout.php` instructed HTMX to always send the Tracy header along which should instruct Tracy to log that request. 
-

Problems: 
- While it displays Tracy just fine on a fresh page load, clicking a boosted link (the main navbar) doesn't refresh Tracy after the body is replaced with the boosted content. 